### PR TITLE
Switched docker-compose jmeter version to 5.2.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
                 build: 
                         context: "jmeter"
                         args:
-                                - jmeterVersion=5.1.1
+                                - jmeterVersion=5.2.1
                 environment:
                         - JMETER_TEST=default_test_plan.jmx
                 depends_on:


### PR DESCRIPTION
Switched docker-compose jmeter version to 5.2.1 since 5.1.1 is not available for downloading anynmore